### PR TITLE
IOS editor snapping Issue resolved and Default title focus disabled.

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -90,7 +90,7 @@ export default class RichTextEditor extends Component {
     const {marginTop = 0, marginBottom = 0} = this.props.style;
     const spacing = marginTop + marginBottom + top + bottom;
 
-    const editorAvailableHeight = Dimensions.get('window').height - keyboardHeight - spacing;
+    const editorAvailableHeight = Dimensions.get('window').height - ( PlatformIOS ? (keyboardHeight * 2) : (keyboardHeight)  ) - spacing;
     this.setEditorHeight(editorAvailableHeight);
   }
 

--- a/src/editor.html
+++ b/src/editor.html
@@ -917,7 +917,7 @@
 				whenPastingInsertAsPlainText('zss_editor_title');
 				whenPastingInsertAsPlainText('zss_editor_content');
 
-				zss_editor.focusTitle();
+				// zss_editor.focusTitle();
 
 				setTimeout(function() {
 					WebViewBridge.send(JSON.stringify({type: 'ZSS_INITIALIZED'}))


### PR DESCRIPTION
1. IOS editor snapping Issue resolved.
2. Default title focus disabled.